### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/perficient-msdynamics.template
+++ b/templates/perficient-msdynamics.template
@@ -150,7 +150,7 @@ Resources:
       MemorySize: 128
       Role:
         Fn::GetAtt: TestFunctionExecutionRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 8
       Code:
         S3Bucket:
@@ -207,7 +207,7 @@ Resources:
       MemorySize: 256
       Role:
         Fn::GetAtt: GetDynamicsTokenFunctionExecutionRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 8
       Code:
         S3Bucket:
@@ -230,7 +230,7 @@ Resources:
       MemorySize: 128
       Role:
         Fn::GetAtt: TestFunctionExecutionRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 8
       Code:
         S3Bucket:
@@ -284,7 +284,7 @@ Resources:
       MemorySize: 256
       Role:
         Fn::GetAtt: DynamicsDataDipFunctionExecutionRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 8
       Code:
         S3Bucket:
@@ -317,7 +317,7 @@ Resources:
       MemorySize: 128
       Role:
         Fn::GetAtt: TestFunctionExecutionRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 8
       Code:
         S3Bucket:
@@ -344,7 +344,7 @@ Resources:
       MemorySize: 256
       Role:
         Fn::GetAtt: DynamicsDataDipFunctionExecutionRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Timeout: 8
       Code:
         S3Bucket:


### PR DESCRIPTION
CloudFormation templates in connect-integration-perficient-msdynamics have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.